### PR TITLE
commit do módulo de Gson

### DIFF
--- a/backend-dev/pom.xml
+++ b/backend-dev/pom.xml
@@ -5,6 +5,7 @@
   <version>0.0.1-SNAPSHOT</version>
   
   <dependencies>
+  
   	<dependency>
 		<groupId>log4j</groupId>
 		<artifactId>log4j</artifactId>
@@ -12,9 +13,28 @@
 	</dependency>
 	
 	<dependency>
-	  <groupId>junit</groupId>
-	  <artifactId>junit</artifactId>
-	  <version>4.12</version>
+	    <groupId>junit</groupId>
+	    <artifactId>junit</artifactId>
+	    <version>4.12</version>
 	</dependency>
+	
+	<dependency>
+	    <groupId>com.google.code.gson</groupId>
+	    <artifactId>gson</artifactId>
+	    <version>2.8.5</version>
+	</dependency>
+	
+	<dependency>
+	    <groupId>org.assertj</groupId>
+	    <artifactId>assertj-core</artifactId>
+	    <version>3.11.1</version>
+	    <scope>test</scope>
+    </dependency>
+	
   </dependencies>
+  
+  <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+	
+  
+  
 </project>

--- a/backend-dev/src/main/java/gson/Exclude.java
+++ b/backend-dev/src/main/java/gson/Exclude.java
@@ -1,0 +1,11 @@
+package gson;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface Exclude {}

--- a/backend-dev/src/main/java/gson/IdExclusion.java
+++ b/backend-dev/src/main/java/gson/IdExclusion.java
@@ -1,0 +1,15 @@
+package gson;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+public class IdExclusion implements ExclusionStrategy {
+
+	public boolean shouldSkipClass(Class<?> arg0) {
+		return false;
+	}
+
+	public boolean shouldSkipField(FieldAttributes f) {
+        return f.getAnnotation(Exclude.class) != null;
+    }
+}

--- a/backend-dev/src/main/java/gson/JavaJsonConvertions.java
+++ b/backend-dev/src/main/java/gson/JavaJsonConvertions.java
@@ -1,0 +1,30 @@
+package gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class JavaJsonConvertions {
+	
+	private JavaJsonConvertions() {}
+
+	// topic 2
+	public static String convertJavaToJson(Person person) {
+		return new Gson().toJson(person);
+	}
+	
+	// topic 3
+	public static Person convertJsonToJava(String personAsJson) {
+		return new Gson().fromJson(personAsJson, Person.class);
+	}
+	
+	// topic 4
+	public static String convertJavaToJsonWithoutExcludedFields(Person person) {
+		return new GsonBuilder().addSerializationExclusionStrategy(new IdExclusion()).create().toJson(person);
+	}
+	
+	// method to see the other way around
+	public static Person convertJsonToJavaWithoutExcludedFields(String personAsJson) {
+		return new GsonBuilder().addDeserializationExclusionStrategy
+				(new IdExclusion()).create().fromJson(personAsJson, Person.class);
+	}
+}

--- a/backend-dev/src/main/java/gson/JavaToJson.java
+++ b/backend-dev/src/main/java/gson/JavaToJson.java
@@ -1,0 +1,16 @@
+package gson;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.apache.log4j.Logger;
+
+public class JavaToJson {
+
+	public static void main(String[] args) {
+		// topic 2
+		Person person = new Person("Bruno", 1, new BigDecimal("1200"), LocalDate.now());
+		Logger logger = Logger.getLogger(JavaToJson.class);
+		logger.info(JavaJsonConvertions.convertJavaToJson(person));
+	}
+}

--- a/backend-dev/src/main/java/gson/JavaToJsonWithoutId.java
+++ b/backend-dev/src/main/java/gson/JavaToJsonWithoutId.java
@@ -1,0 +1,16 @@
+package gson;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.apache.log4j.Logger;
+
+public class JavaToJsonWithoutId {
+
+	public static void main(String[] args) {
+		// topic 4
+		Person person = new Person("Ricardo", 10, new BigDecimal("2000"), LocalDate.now());
+		Logger logger = Logger.getLogger(JavaToJsonWithoutId.class);
+		logger.info(JavaJsonConvertions.convertJavaToJsonWithoutExcludedFields(person));
+	}
+}

--- a/backend-dev/src/main/java/gson/JsonToJava.java
+++ b/backend-dev/src/main/java/gson/JsonToJava.java
@@ -1,0 +1,14 @@
+package gson;
+
+import org.apache.log4j.Logger;
+
+public class JsonToJava {
+
+	public static void main(String[] args) {
+		// topic 3
+		Logger logger = Logger.getLogger(JsonToJava.class);
+		Person person = JavaJsonConvertions.convertJsonToJava(
+				"{\"name\":\"Rafael\",\"id\":2,\"salary\":1500,\"registrationDate\":{\"year\":2017,\"month\":9,\"day\":21}}");
+		logger.info(person);
+	}
+}

--- a/backend-dev/src/main/java/gson/Person.java
+++ b/backend-dev/src/main/java/gson/Person.java
@@ -1,0 +1,100 @@
+package gson;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// topic 1
+public class Person {
+
+	private String name;
+	@Exclude
+	private Integer id;
+	private BigDecimal salary;
+	private LocalDate registrationDate;
+
+	public Person(String name, Integer id, BigDecimal salary, LocalDate registrationDate) {
+		this.name = name;
+		this.id = id;
+		this.salary = salary;
+		this.registrationDate = registrationDate;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public void setSalary(BigDecimal salary) {
+		this.salary = salary;
+	}
+
+	public void setRegistrationDate(LocalDate registrationDate) {
+		this.registrationDate = registrationDate;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public BigDecimal getSalary() {
+		return salary;
+	}
+
+	public LocalDate getRegistrationDate() {
+		return registrationDate;
+	}
+
+	public String toString() {
+		return getName() + ", " + getId() + ", " + getSalary() + ", " + getRegistrationDate();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((registrationDate == null) ? 0 : registrationDate.hashCode());
+		result = prime * result + ((salary == null) ? 0 : salary.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Person other = (Person) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (registrationDate == null) {
+			if (other.registrationDate != null)
+				return false;
+		} else if (!registrationDate.equals(other.registrationDate))
+			return false;
+		if (salary == null) {
+			if (other.salary != null)
+				return false;
+		} else if (!salary.equals(other.salary))
+			return false;
+		return true;
+	}
+}

--- a/backend-dev/src/test/java/gsontest/JavaJsonConvertionsTest.java
+++ b/backend-dev/src/test/java/gsontest/JavaJsonConvertionsTest.java
@@ -1,0 +1,40 @@
+package gsontest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.Test;
+import gson.JavaJsonConvertions;
+import gson.Person;
+
+public class JavaJsonConvertionsTest {
+
+	@Test
+	public void testConvertJavaToJson() {
+		assertThat(JavaJsonConvertions.convertJavaToJson(new Person("Bruno", 1, new BigDecimal("1200"), LocalDate.parse("2018-09-21"))))
+			.isEqualTo("{\"name\":\"Bruno\",\"id\":1,\"salary\":1200,\"registrationDate\":{\"year\":2018,\"month\":9,\"day\":21}}");
+	}
+
+	@Test
+	public void testConvertJsonToJava() {
+		Person person = new Person("Bruno", 1, new BigDecimal("1200"), LocalDate.parse("2018-09-21")); 
+		String json = JavaJsonConvertions.convertJavaToJson(person);
+		assertThat(JavaJsonConvertions.convertJsonToJava(json)).isEqualTo(person);
+	}
+
+	@Test
+	public void testConvertJavaToJsonWithoutExcludedFields() {
+		Person person = new Person("Bruno", 1, new BigDecimal("1200"), LocalDate.parse("2018-09-21"));
+		assertThat(JavaJsonConvertions.convertJavaToJsonWithoutExcludedFields(person)).
+			isEqualTo("{\"name\":\"Bruno\",\"salary\":1200,\"registrationDate\":{\"year\":2018,\"month\":9,\"day\":21}}");
+	}
+
+	@Test
+	public void testConvertJsonToJavaWithoutExcludedFields() {
+		Person person = new Person("Bruno", 1, new BigDecimal("1200"), LocalDate.parse("2018-09-21")); 
+		// easier than insert the whole string
+		String json = JavaJsonConvertions.convertJavaToJsonWithoutExcludedFields(person);
+		person.setId(null); // id becomes null with this method
+		assertThat(JavaJsonConvertions.convertJsonToJavaWithoutExcludedFields(json)).isEqualTo(person);
+	}
+}


### PR DESCRIPTION
. Achei 3 maneiras de fazer o tópico 4:
1) transient: adicionar aos atributos que não quero converter para JSON, o problema é que essa propriedade não o restringe apenas ao Gson, mas a todos os tipos de serialização, o que poderia causar futuros problemas.
2) @Expose: anotação para todos os atributos que quero que sejam serializados, mas causa bastante poluição do código pelo seu uso excessivo.
3) (Como implementei): Exclusion Strategy: criei uma anotação customizada (anotações runtime e target.field), implementei essa anotação e defini que todos os atributos com a anotação @Exclude não devem ser convertidos para JSON.